### PR TITLE
Made seeking and range requests decrypt properly

### DIFF
--- a/buckets/download.go
+++ b/buckets/download.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/StarHack/go-internxt-drive/config"
 )
@@ -111,7 +113,13 @@ func DownloadFile(cfg *config.Config, fileID, destPath string) error {
 
 // DownloadFileStream returns a ReadCloser that streams the decrypted contents
 // of the file with the given UUID. The caller must close the returned ReadCloser.
-func DownloadFileStream(cfg *config.Config, fileUUID string) (io.ReadCloser, error) {
+// It takes an optional range header in the format of either "bytes=100-199" or "bytes=100-".
+func DownloadFileStream(cfg *config.Config, fileUUID string, optionalRange ...string) (io.ReadCloser, error) {
+	rangeValue := ""
+	if len(optionalRange) > 0 {
+		rangeValue = optionalRange[0]
+	}
+
 	// 1) Fetch file info (including shards and index)
 	info, err := GetBucketFileInfo(cfg, cfg.Bucket, fileUUID)
 	if err != nil {
@@ -125,11 +133,53 @@ func DownloadFileStream(cfg *config.Config, fileUUID string) (io.ReadCloser, err
 	// 2) Derive fileKey and IV from the stored index
 	key, iv, err := GenerateFileKey(cfg.Mnemonic, cfg.Bucket, info.Index)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to generate file key: %w", err)
 	}
 
-	// 3) Download the encrypted shard
-	resp, err := http.Get(shard.URL)
+	// 3) Calculate the IV for the requested range
+	if rangeValue != "" {
+		startByte, endByte, err := getStartByteAndEndByte(rangeValue)
+		if err != nil {
+			return nil, fmt.Errorf("invalid range: %w", err)
+		}
+
+		// Ensure AES block alignment for correct decryption
+		// Find the nearest block and call this function again with the adjusted range, then discard the unwanted bytes before returning
+		if offset := startByte % 16; offset != 0 {
+			alignedStart := startByte - offset
+			var adjustedRange string
+			if endByte == -1 {
+				adjustedRange = fmt.Sprintf("bytes=%d-", alignedStart)
+			} else {
+				adjustedRange = fmt.Sprintf("bytes=%d-%d", alignedStart, endByte)
+			}
+
+			stream, err := DownloadFileStream(cfg, fileUUID, adjustedRange)
+			if err != nil {
+				return nil, err
+			}
+
+			// Discard unwanted bytes and return the requested range exactly
+			if _, err := io.CopyN(io.Discard, stream, int64(offset)); err != nil {
+				stream.Close()
+				return nil, fmt.Errorf("failed to discard offset bytes: %w", err)
+			}
+			return stream, nil
+		}
+
+		adjustIV(iv, startByte/16)
+	}
+
+	// 4) Download the encrypted shard, include the Range header if any
+	req, err := http.NewRequest("GET", shard.URL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if rangeValue != "" {
+		req.Header.Set("Range", rangeValue)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -139,16 +189,60 @@ func DownloadFileStream(cfg *config.Config, fileUUID string) (io.ReadCloser, err
 		return nil, fmt.Errorf("shard download failed: %d %s", resp.StatusCode, string(body))
 	}
 
-	// 4) Wrap in AES‑CTR decryptor
+	// 5) Wrap in AES‑CTR decryptor
 	decReader, err := DecryptReader(resp.Body, key, iv)
 	if err != nil {
 		resp.Body.Close()
 		return nil, err
 	}
 
-	// 5) Return a ReadCloser that closes the HTTP body when closed
+	// 6) Return a ReadCloser that closes the HTTP body when closed
 	return struct {
 		io.Reader
 		io.Closer
 	}{Reader: decReader, Closer: resp.Body}, nil
+}
+
+// This will return the startByte and endByte of a range header in these formats: "bytes=100-199" or "bytes=100-"
+// In the case of the "bytes=100-" the returned endByte will be -1.
+// Formats like "bytes=-200" and "bytes=0-99,200-299" are not supported.
+func getStartByteAndEndByte(rangeHeader string) (int, int, error) {
+	if !strings.HasPrefix(rangeHeader, "bytes=") {
+		return 0, 0, fmt.Errorf("invalid Range header format")
+	}
+
+	rangePart := strings.TrimPrefix(rangeHeader, "bytes=")
+	parts := strings.Split(rangePart, "-")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid Range header format")
+	}
+
+	startByte, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid start byte in Range header: %w", err)
+	}
+
+	// Handle optional endByte
+	if parts[1] == "" {
+		return startByte, -1, nil
+	}
+
+	endByte, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid end byte in Range header: %w", err)
+	}
+
+	return startByte, endByte, nil
+}
+
+// adjustIV increments the IV based on the given block index.
+func adjustIV(iv []byte, blockIndex int) {
+	for i := 0; i < blockIndex; i++ {
+		for j := len(iv) - 1; j >= 0; j-- {
+			iv[j]++
+			if iv[j] != 0 {
+				break
+			}
+		}
+	}
 }


### PR DESCRIPTION
Added logic to recalculate IV based on requested range. This will make it possible to request a specific range of a file and still have it decrypt properly. Seeking in videos etc. should work with this fix. This should also ensure block alignment for correct decryption.

For use in rclone, the `Open` function in `internxt.go` will need to be adjusted to something like  this:

```
// Open opens a file for streaming
func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
	fs.FixRangeOption(options, o.size)
	rangeValue := ""
	for _, option := range options {
		switch option.(type) {
		case *fs.RangeOption, *fs.SeekOption:
			_, rangeValue = option.Header()
		}
	}

	return buckets.DownloadFileStream(o.f.cfg, o.id, rangeValue)
}
```

Testing this can be done using rclone with the cat command. Something like `rclone cat internxt:somefile.txt --offset 3 --count 10`.

The same logic will also work when uploading so that rclone can open more than one connection when uploading big files and upload multiple chunks at once.

This is my first time writing go and I am not familiar with the language or libraries. Perhaps there are functions in the std lib that handles this better.