### PR TITLE
[PB-4838]: refactor/centralized http client

### DIFF
--- a/auth/access.go
+++ b/auth/access.go
@@ -17,7 +17,7 @@ import (
 
 	"crypto/sha1"
 
-	"github.com/StarHack/go-internxt-drive/config"
+	"github.com/internxt/rclone/config"
 
 	"golang.org/x/crypto/pbkdf2"
 )
@@ -70,7 +70,14 @@ func AccessLogin(cfg *config.Config, lr *LoginResponse) (*AccessResponse, error)
 	}
 
 	b, _ := json.Marshal(req)
-	resp, err := http.Post(cfg.DriveAPIURL+"/auth/login/access", "application/json", bytes.NewReader(b))
+
+	httpReq, err := http.NewRequest(http.MethodPost, cfg.DriveAPIURL+"/auth/login/access", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := cfg.HTTPClient.Do(httpReq)
 	if err != nil {
 		return nil, err
 	}
@@ -110,8 +117,7 @@ func AreCredentialsCorrect(cfg *config.Config, hashedPassword string) (bool, err
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return false, err
 	}

--- a/auth/login.go
+++ b/auth/login.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/StarHack/go-internxt-drive/config"
+	"github.com/internxt/rclone/config"
 )
 
 type LoginResponse struct {
@@ -21,7 +21,14 @@ type LoginResponse struct {
 func Login(cfg *config.Config) (*LoginResponse, error) {
 	payload := map[string]string{"email": cfg.Email}
 	b, _ := json.Marshal(payload)
-	resp, err := http.Post(cfg.DriveAPIURL+"/auth/login", "application/json", bytes.NewReader(b))
+
+	req, err := http.NewRequest(http.MethodPost, cfg.DriveAPIURL+"/auth/login", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/logout.go
+++ b/auth/logout.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/StarHack/go-internxt-drive/config"
+	"github.com/internxt/rclone/config"
 )
 
 // Logout calls GET {DRIVE_API_URL}/logout to end the session.
@@ -17,7 +17,7 @@ func Logout(cfg *config.Config) error {
 		return err
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/auth/tfa.go
+++ b/auth/tfa.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/StarHack/go-internxt-drive/config"
+	"github.com/internxt/rclone/config"
 )
 
 type TFAEnableRequest struct {
@@ -34,7 +34,7 @@ func IsTFAEnabled(cfg *config.Config) (bool, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return false, err
 	}
@@ -58,7 +58,7 @@ func FetchTFASetup(cfg *config.Config) (*TFASecretResponse, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func EnableTFA(cfg *config.Config, key, code string) error {
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func DisableTFA(cfg *config.Config, code string) error {
 	req.Header.Set("Content-Type", "application/json")
 	req.ContentLength = int64(len(bodyBytes))
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/buckets/download.go
+++ b/buckets/download.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/StarHack/go-internxt-drive/config"
+	"github.com/internxt/rclone/config"
 )
 
 const bucketAPIBase = "https://api.internxt.com"
@@ -46,7 +46,7 @@ func GetBucketFileInfo(cfg *config.Config, bucketID, fileID string) (*BucketFile
 	req.Header.Set("internxt-version", "1.0")
 	req.Header.Set("internxt-client", "internxt-go-sdk")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,11 @@ func DownloadFile(cfg *config.Config, fileID, destPath string) error {
 	}
 
 	// 3) GET the encrypted shard directly from its presigned URL
-	resp, err := http.Get(shard.URL)
+	req, err := http.NewRequest("GET", shard.URL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -179,7 +183,7 @@ func DownloadFileStream(cfg *config.Config, fileUUID string, optionalRange ...st
 		req.Header.Set("Range", rangeValue)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/buckets/finish.go
+++ b/buckets/finish.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/StarHack/go-internxt-drive/config"
+	"github.com/internxt/rclone/config"
 )
 
 type Shard struct {
@@ -46,7 +46,7 @@ func FinishUpload(cfg *config.Config, bucketID, index string, shards []Shard) (*
 	req.Header.Set("internxt-client", "drive-web")
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/buckets/meta.go
+++ b/buckets/meta.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/StarHack/go-internxt-drive/config"
+	"github.com/internxt/rclone/config"
 )
 
 type CreateMetaRequest struct {
@@ -65,7 +65,7 @@ func CreateMetaFile(cfg *config.Config, name, bucketID, fileID, encryptVersion, 
 	req.Header.Set("internxt-version", "v1.0.436")
 	req.Header.Set("internxt-client", "drive-web")
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/buckets/start.go
+++ b/buckets/start.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/StarHack/go-internxt-drive/config"
+	"github.com/internxt/rclone/config"
 )
 
 const API = "https://api.internxt.com"
@@ -48,7 +48,7 @@ func StartUpload(cfg *config.Config, bucketID string, parts []UploadPartSpec) (*
 	req.Header.Set("internxt-client", "drive-web")
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/buckets/transfer.go
+++ b/buckets/transfer.go
@@ -4,16 +4,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/internxt/rclone/config"
 )
 
-func Transfer(part UploadPart, r io.Reader, size int64) error {
+func Transfer(cfg *config.Config, part UploadPart, r io.Reader, size int64) error {
 	req, err := http.NewRequest("PUT", part.URL, r)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.ContentLength = size
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/buckets/upload.go
+++ b/buckets/upload.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/StarHack/go-internxt-drive/config"
+	"github.com/internxt/rclone/config"
 )
 
 func UploadFile(cfg *config.Config, filePath, targetFolderUUID string, modTime time.Time) (*CreateMetaResponse, error) {
@@ -21,9 +21,7 @@ func UploadFile(cfg *config.Config, filePath, targetFolderUUID string, modTime t
 		return nil, err
 	}
 	plainSize := int64(len(raw))
-	ph := sha256.Sum256(raw)
-
-	ph = [32]byte{}
+	var ph [32]byte
 	if _, err := rand.Read(ph[:]); err != nil {
 		return nil, fmt.Errorf("cannot generate random index: %w", err)
 	}
@@ -52,7 +50,7 @@ func UploadFile(cfg *config.Config, filePath, targetFolderUUID string, modTime t
 		return nil, err
 	}
 	part := startResp.Uploads[0]
-	if err := Transfer(part, r, plainSize); err != nil {
+	if err := Transfer(cfg, part, r, plainSize); err != nil {
 		return nil, err
 	}
 	encIndex := hex.EncodeToString(ph[:])
@@ -109,7 +107,7 @@ func UploadFileStream(cfg *config.Config, targetFolderUUID, fileName string, in 
 
 	part := startResp.Uploads[0]
 
-	if err := Transfer(part, r, plainSize); err != nil {
+	if err := Transfer(cfg, part, r, plainSize); err != nil {
 		return nil, err
 	}
 

--- a/files/files.go
+++ b/files/files.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/StarHack/go-internxt-drive/config"
-	"github.com/StarHack/go-internxt-drive/folders"
+	"github.com/internxt/rclone/config"
+	"github.com/internxt/rclone/folders"
 )
 
 const filesPath = "/files"
@@ -23,7 +23,7 @@ func GetFileMeta(cfg *config.Config, fileUUID string) (*folders.File, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func DeleteFile(cfg *config.Config, uuid string) error {
 		return err
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func UpdateFileMeta(cfg *config.Config, fileUUID string, updated *folders.File) 
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func MoveFile(cfg *config.Config, fileUUID, destinationFolderUUID string) (*fold
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func RenameFile(cfg *config.Config, fileUUID, newPlainName, newType string) erro
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ func GetRecentFiles(cfg *config.Config, limit int) ([]folders.File, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/folders/folders.go
+++ b/folders/folders.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/StarHack/go-internxt-drive/config"
+	"github.com/internxt/rclone/config"
 )
 
 const foldersPath = "/folders"
@@ -39,7 +39,7 @@ func CreateFolder(cfg *config.Config, reqBody CreateFolderRequest) (*Folder, err
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func DeleteFolder(cfg *config.Config, uuid string) error {
 		return err
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func GetFolderSize(cfg *config.Config, uuid string) (int64, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return 0, fmt.Errorf("GetFolderSize: request failed: %w", err)
 	}
@@ -154,7 +154,7 @@ func ListFolders(cfg *config.Config, parentUUID string, opts ListOptions) ([]Fol
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func ListFiles(cfg *config.Config, parentUUID string, opts ListOptions) ([]File,
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +297,7 @@ func RenameFolder(cfg *config.Config, uuid, newName string) error {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("RenameFolder: request failed: %w", err)
 	}
@@ -331,7 +331,7 @@ func MoveFolder(cfg *config.Config, uuid, destUUID string) error {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("MoveFolder: request failed: %w", err)
 	}
@@ -354,7 +354,7 @@ func Tree(cfg *config.Config, uuid string) (*TreeNode, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("Tree: request failed: %w", err)
 	}
@@ -387,7 +387,7 @@ func Ancestors(cfg *config.Config, uuid string) ([]Folder, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("Ancestors: request failed: %w", err)
 	}
@@ -420,7 +420,7 @@ func GetFolderMetadataById(cfg *config.Config, id int64) (*Folder, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("GetFolderMetadata: request failed: %w", err)
 	}
@@ -449,7 +449,7 @@ func GetFolderMetadataByUUID(cfg *config.Config, uuid string) (*Folder, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("GetFolderMeta: request failed: %w", err)
 	}
@@ -478,7 +478,7 @@ func GetMetadataByPath(cfg *config.Config, path string) (*Folder, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("GetMetadataByPath: request failed: %w", err)
 	}

--- a/fuzzy/fuzzy.go
+++ b/fuzzy/fuzzy.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/StarHack/go-internxt-drive/config"
+	"github.com/internxt/rclone/config"
 )
 
 type SearchResult struct {
@@ -33,7 +33,7 @@ func FuzzySearch(cfg *config.Config, term string, offset int) (*SearchResponse, 
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/StarHack/go-internxt-drive
+module github.com/internxt/rclone
 
 go 1.23.0
 

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
+github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
+golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/trash/trash.go
+++ b/trash/trash.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/StarHack/go-internxt-drive/config"
-	"github.com/StarHack/go-internxt-drive/folders"
+	"github.com/internxt/rclone/config"
+	"github.com/internxt/rclone/folders"
 )
 
 type TrashType string
@@ -61,7 +61,7 @@ func GetPaginatedTrashFolders(cfg *config.Config, limit, offset int, sort SortFi
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func GetPaginatedTrashFiles(cfg *config.Config, limit, offset int, sort SortFiel
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func AddToTrash(cfg *config.Config, items []TrashRef) error {
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func DeleteAllTrash(cfg *config.Config) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func RequestDeleteAllTrash(cfg *config.Config) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func DeleteSpecifiedTrashItems(cfg *config.Config, items []TrashRef) error {
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -232,7 +232,7 @@ func DeleteTrashFile(cfg *config.Config, fileID string) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -253,7 +253,7 @@ func DeleteTrashFolder(cfg *config.Config, folderID int64) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/users/limit.go
+++ b/users/limit.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/StarHack/go-internxt-drive/config"
+	"github.com/internxt/rclone/config"
 )
 
 type LimitResponse struct {
@@ -22,7 +22,7 @@ func GetLimit(cfg *config.Config) (*LimitResponse, error) {
 	}
 
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/users/usage.go
+++ b/users/usage.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/StarHack/go-internxt-drive/config"
+	"github.com/internxt/rclone/config"
 )
 
 type UsageResponse struct {
@@ -22,7 +22,7 @@ func GetUsage(cfg *config.Config) (*UsageResponse, error) {
 	}
 
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/workspaces/workspaces.go
+++ b/workspaces/workspaces.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/StarHack/go-internxt-drive/config"
+	"github.com/internxt/rclone/config"
 )
 
 const workspacesPath = "/workspaces"
@@ -65,7 +65,7 @@ func GetWorkspaces(cfg *config.Config) (*WorkspacesResponse, error) {
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.Token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := cfg.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously on each api call `http.DefaultClient` was being used. This PR introduces a centralized http client injected through config, which has some settings like timeouts setup